### PR TITLE
Push unclosed opening tags correctly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,4 +40,4 @@ jobs:
           toolchain: "stable"
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
-      - run: cargo hack test --feature-powerset
+      - run: cargo hack test --feature-powerset --skip debug_trace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,9 @@
 name = "bubble-bath"
 version = "0.1.0"
 edition = "2021"
-description = "Speedy HTML sanitizer"
+description = "Small and quick HTML sanitizer"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/aumetra/bubble-bath"
 publish = false
 
 [[bench]]
@@ -29,6 +30,9 @@ thiserror = "1.0.50"
 
 [features]
 default = ["simd"]
+# Enables the `lol_html` `debug_trace` feature. Do not use in production!
+debug_trace = ["lol_html/debug_trace"]
+# Enables SIMD acceleration for some operations we have to perform
 simd = [
     "bytecount/runtime-dispatch-simd",
     "dep:simdutf8",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -44,9 +44,12 @@ name = "bubble-bath"
 version = "0.1.0"
 dependencies = [
  "ahash",
+ "bytecount",
  "lol_html",
  "once_cell",
+ "simdutf8",
  "slab",
+ "thiserror",
 ]
 
 [[package]]
@@ -56,6 +59,12 @@ dependencies = [
  "bubble-bath",
  "libfuzzer-sys",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "byteorder"
@@ -480,6 +489,12 @@ dependencies = [
  "nodrop",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "siphasher"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -21,7 +21,7 @@ members = ["."]
 debug = 1
 
 [[bin]]
-name = "fuzz_target_1"
-path = "fuzz_targets/fuzz_target_1.rs"
+name = "basic"
+path = "fuzz_targets/basic.rs"
 test = false
 doc = false

--- a/tests/ammonia_tests.rs
+++ b/tests/ammonia_tests.rs
@@ -18,6 +18,13 @@ fn deeply_nested_alternating() {
 }
 
 #[test]
+fn included_angles() {
+    let fragment = "1 < 2";
+    let result = clean(fragment).unwrap();
+    assert_eq!(result, "1 &lt; 2");
+}
+
+#[test]
 fn remove_script() {
     let fragment = "an <script>evil()</script> example";
     let result = clean(fragment).unwrap();

--- a/tests/snapshots/torture__torture@extra_open_bracket.snap
+++ b/tests/snapshots/torture__torture@extra_open_bracket.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/torture.rs
-expression: "bubble_bath::clean(&input).unwrap()"
+expression: "bubble_bath::clean(input).unwrap()"
 input_file: tests/inputs/extra_open_bracket
 ---
-&lt;&gt;&gt;
+&lt;

--- a/tests/snapshots/torture__torture_escaped@extra_open_bracket.snap
+++ b/tests/snapshots/torture__torture_escaped@extra_open_bracket.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/torture.rs
-expression: bubble_bath.clean(&input).unwrap()
+expression: bubble_bath.clean(input).unwrap()
 input_file: tests/inputs/extra_open_bracket
 ---
-&lt;&gt;&gt;
+&lt;


### PR DESCRIPTION
Previously we just unconditionally pushed closing tags into the rewriter.  
This worked for the tests but would have added unnecessary tags at the end on inputs such as `1 < 2`.

This PR adds some additional book-keeping that subtracts all unclosed opening tags if they are contained inside a comment or text, since comments get removed and texts are getting escaped.